### PR TITLE
Make API selftest configurable via enable_api_selftest setting

### DIFF
--- a/Koha/Plugin/Com/BibLibre/EasyPayments.pm
+++ b/Koha/Plugin/Com/BibLibre/EasyPayments.pm
@@ -76,7 +76,7 @@ sub opac_online_payment {
         return;
     }
 
-    if ( $conf->{payment_provider} eq 'easy' ) {
+    if ( $conf->{payment_provider} eq 'easy' && $self->retrieve_data('enable_api_selftest') ) {
         my $callback_url = URI->new_abs(
             'api/v1/contrib/' . $self->api_namespace . '/callback',
             C4::Context->preference('OPACBaseURL') . '/'
@@ -513,6 +513,7 @@ sub configure {
                 netaxept_live_key => scalar $cgi->param('netaxept_live_key'),
                 netaxept_test_key => scalar $cgi->param('netaxept_test_key'),
                 netaxept_single_page_terminal => scalar $cgi->param('netaxept_single_page_terminal'),
+                enable_api_selftest => scalar $cgi->param('enable_api_selftest'),
             }
         );
         $self->go_home();
@@ -535,6 +536,7 @@ sub configure {
             netaxept_live_key => $self->retrieve_data('netaxept_live_key'),
             netaxept_test_key => $self->retrieve_data('netaxept_test_key'),
             netaxept_single_page_terminal => $self->retrieve_data('netaxept_single_page_terminal'),
+            enable_api_selftest => $self->retrieve_data('enable_api_selftest'),
         );
 
         $self->output_html( $template->output() );

--- a/Koha/Plugin/Com/BibLibre/EasyPayments/configure.tt
+++ b/Koha/Plugin/Com/BibLibre/EasyPayments/configure.tt
@@ -83,6 +83,14 @@
         <label for="easy_terms">Terms and conditions: </label>
         <textarea name="easy_terms" id="terms" cols="75" rows="10">[% easy_terms | $raw %]</textarea>
         </li>
+        <li>
+        <label for="enable_api_selftest">Enable API selftest: </label>
+        <select id="enable_api_selftest" name="enable_api_selftest">
+            <option value="0">No</option>
+            <option value="1"[% IF enable_api_selftest %] selected="selected"[% END %]>Yes</option>
+        </select>
+        <span class="hint">Tests API connectivity on each payment page load (may cause delays)</span>
+        </li>
         </ol>
         </fieldset>
         <fieldset class="rows">


### PR DESCRIPTION
Makes the API connectivity test optional to avoid unnecessary delays on payment page load.

### Changes
- Added enable_api_selftest configuration option in Nets Easy settings
- API selftest only runs when explicitly enabled
- Disabled by default to avoid delays